### PR TITLE
Add RJUMPV

### DIFF
--- a/EIPS/eip-4200.md
+++ b/EIPS/eip-4200.md
@@ -2,7 +2,7 @@
 eip: 4200
 title: Static relative jumps
 description: RJUMP and RJUMPI instructions with a signed immediate encoding the jump destination
-author: Alex Beregszaszi (@axic), Andrei Maiboroda (@gumb0), Paweł Bylica (@chfast)
+author: Alex Beregszaszi (@axic), Andrei Maiboroda (@gumb0), Paweł Bylica (@chfast), Greg Colvin (@gcolvin)
 discussions-to: https://ethereum-magicians.org/t/eip-3920-static-relative-jumps/7108
 status: Draft
 type: Standards Track
@@ -13,7 +13,7 @@ requires: 3540, 3670
 
 ## Abstract
 
-Two new EVM jump instructions are introduced (`RJUMP` and `RJUMPI`) which encode the destination as a signed immediate value. These can be useful in the majority of (but not all) use cases and offer a cost reduction.
+Three new EVM jump instructions are introduced (`RJUMP`, `RJUMPI`, and `RJUMPV`) which encode the destination as a signed immediate value. These can be useful in the majority of (but not all) use cases and offer a cost reduction.
 
 ## Motivation
 
@@ -26,7 +26,7 @@ There are various ways to reduce the need for dynamic jumps, some examples:
 2. A "return to caller" instruction
 3. A "switch-case" table with dynamic indexing
 
-This change does not attempt to solve these, but instead introduces a minimal feature set to allow compilers to decide which is the most adequate option for a given use case. It is expected that compilers will use `RJUMP`/`RJUMPI` almost exclusively, with the exception of returning to the caller continuing to use `JUMP`.
+This change does not attempt to solve (1) or (2), but instead introduces a minimal feature set to allow compilers to decide which is the most adequate option for a given use case. It is expected that compilers will use `RJUMP`/`RJUMPI`/`RJUMPV` almost exclusively, with the exception of returning to the caller continuing to use `JUMP`.
 
 This functionality does not preclude the EVM from introducing other forms of control flow later on. `RJUMP`/`RJUMPI` can efficiently co-exists with a higher-level declaration of functions, where static relative jumps should be used for intra-function control flow.
 
@@ -37,18 +37,20 @@ The main benefit of these instruction is reduced gas cost (both at deploy and ex
 We introduce two new instructions on the same block number [EIP-3540](./eip-3540.md) is activated on:
 1. `RJUMP` (0x5c)
 2. `RJUMPI` (0x5d)
+2. `RJUMPV` (0x5e)
 
 If the code is legacy bytecode, both of these instructions result in an *exceptional halt*. (*Note: This means no change to behaviour.*)
 
 If the code is valid EOF1:
 1. `RJUMP relative_offset` (0x5c), sets the `PC` to `PC_post_instruction + relative_offset`.
 2. `RJUMPI relative_offset` (0x5d), pops a value (`condition`) from the stack, and sets the `PC` to `PC_post_instruction + ((condition == 0) ? 0 : relative_offset)`.
+2. `RJUMPI count [count]relative_offsets` (0x5e), pops a value (`inded`) from the stack, and sets the `PC` to `PC_post_instruction + ((index >= count) ? default : relative_offset[count])`.
 
-The immediate argument `relative_offset` is encoded as a 16-bit **signed** (two's-complement) big-endian value. Under `PC_post_instruction` we mean the `PC` position after the entire immediate value.
+The immediate arguments are encoded as a 16-bit **signed** (two's-complement) big-endian value. Under `PC_post_instruction` we mean the `PC` position after the entire immediate value.
 
-We also extend the validation algorithm of [EIP-3670](./eip-3670.md) to verify that each `RJUMP`/`RJUMPI` has a `relative_offset` pointing to an instruction. This means it cannot point to an immediate data of `PUSHn`/`RJUMP`/`RJUMPI`. It cannot point outside of code bounds. It is allowed to point to a `JUMPDEST`, but is not required to.
+We also extend the validation algorithm of [EIP-3670](./eip-3670.md) to verify that each `RJUMP`/`RJUMPI`/`RJUMPV` has `relative_offset`[s] pointing to an instruction. This means it cannot point to an immediate data of `PUSHn`/`RJUMP`/`RJUMPI`. It cannot point outside of code bounds. It is allowed to point to a `JUMPDEST`, but is not required to.
 
-Because the destinations are validated upfront, the cost of these instructions are less than their dynamic counterparts: `RJUMP` should cost 5, and `RJUMPI` should cost 7. This is a reduction of 2 gas, compared to `JUMP` and `JUMPI`.
+Because the destinations are validated upfront, the cost of these instructions are less than their dynamic counterparts: `RJUMP` should cost 5, and `RJUMPI` should cost 7. This is a reduction of 2 gas, compared to `JUMP` and `JUMPI`.  `RJUMPV` should cost the same as `JUMP` at 9 gas.
 
 ## Rationale
 
@@ -69,6 +71,10 @@ Given `MAX_CODE_SIZE = 24576` (in [EIP-170](./eip-170.md)) and `MAX_INITCODE_SIZ
 A version with an 8-bit immediate would only allow moving `PC` backward by 125 or forward by 127 bytes. While that seems to be a good enough distance for many for-loops, it is likely not good enough for cross-function jumps, and since the 16-bit immediate is the same size as what a dynamic jump would take in such cases (3 bytes: `JUMP PUSH1 n`), we think having less instructions is better.
 
 Should there be a need to have immediate encodings of other size (such as 8-bits, 24-bits or 32-bits), it would be possible to introduce new opcodes, similarly to how multiple `PUSH` instructions exist.
+
+### Immediate jump vectors
+
+The `RJUMPV` destination vectors are coded inline rather than in external tables.  This means that the tables cannot be shared.  This is necessary to prevent denial of service attacks on the validation algorithm where code can consist shared `RJUMPV` instructions that address all of the other instructions and take quadratic, rather than linear time to validate.
 
 ### `PUSHn JUMP` sequences
 


### PR DESCRIPTION
Propose an RJUMPV instruction that takes a vector of indexed destinations as immediate arguments.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
