### PR TITLE
Update eip-3779.md

### DIFF
--- a/EIPS/eip-3779.md
+++ b/EIPS/eip-3779.md
@@ -381,6 +381,3 @@ Alex Beregszaszi, Andrei Maiboroda, Paweł Bylica, "EIP-4200: Static relative ju
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-
-
-


### PR DESCRIPTION
This EIP specifies validity rules that ensure that:
> Valid contracts will not halt with an exception unless they either
> * throw `out of gas` or
> * recursively overflow stack.